### PR TITLE
Enhance API helper with documentation and functionality improvements

### DIFF
--- a/lib/contexts/ApiHelperProvider.tsx
+++ b/lib/contexts/ApiHelperProvider.tsx
@@ -26,6 +26,29 @@ const defaultQueryClientConfig: QueryClientConfig = {
   },
 };
 
+/**
+ * Context provider for providing Axios instance and Query Client for API requests.
+ * This provider wraps your app to ensure that the API helper context is accessible and
+ * queries can be persisted using AsyncStorage.
+ *
+ *
+ * @example
+ * import {ApiHelperProvider} from 'react-api-utils';
+ *
+ * function App() {
+ *   return (
+ *     <ApiHelperProvider baseURL="https://api.example.com">
+ *       <YourComponent />
+ *     </ApiHelperProvider>
+ *   );
+ * }
+ *
+ * @param {string} baseURL - The base URL for all API requests.
+ * @param {AxiosRequestConfig} [axiosConfig={}] - Optional configuration to extend or override the default Axios config.
+ * @param {QueryClientConfig} [queryClientConfig={}] - Optional configuration to extend or override the default React Query client config.
+ * @param {ReactNode} children - The children components that can access the API context.
+ */
+
 const ApiHelperProvider: React.FC<ApiHelperProviderProps> = ({
   baseURL,
   axiosConfig = {},

--- a/lib/hooks/useApiHelper.ts
+++ b/lib/hooks/useApiHelper.ts
@@ -1,7 +1,60 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { ApiHelperResult, useApiHelperProps } from '../types';
+import {
+  QueryKey,
+  useMutation,
+  UseMutationResult,
+  useQuery,
+  UseQueryResult,
+} from '@tanstack/react-query';
+import { useApiHelperProps } from '../types';
 import { apiRequest } from '../utils';
 import { useApiHelperContext } from '../contexts';
+import { AxiosRequestConfig } from 'axios';
+
+export function useApiHelper<responseType, errorType>(options: {
+  method: 'GET';
+  url: string;
+  queryKey: QueryKey;
+  params?: Record<string, unknown>;
+  axiosOptions?: AxiosRequestConfig;
+}): UseQueryResult<responseType, errorType>;
+
+export function useApiHelper<responseType, errorType, payloadType>(options: {
+  method: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  url: string;
+  params?: Record<string, unknown>;
+  axiosOptions?: AxiosRequestConfig;
+  onSuccess?: (data: responseType) => void;
+  onError?: (error: errorType) => void;
+}): UseMutationResult<responseType, errorType, payloadType>;
+
+/**
+ * A custom hook for making API requests using React Query.
+ *
+ * @param options Configuration options for the API request.
+ * @returns Either a `UseQueryResult` (for GET requests) or a `UseMutationResult` (for POST, PUT, PATCH, or DELETE requests).
+ *
+ * @example
+ * // Usage example for a GET request:
+ * const result = useApiHelper({
+ *   method: 'GET',
+ *   url: '/users',
+ *   queryKey: 'users-query'
+ * });
+ *
+ *
+ * @example
+ * // Usage example for a POST request:
+ * const { mutate } = useApiHelper({
+ *   method: 'POST',
+ *   url: '/todos',
+ *   onSuccess: (data) => console.log(data),
+ *   onError: (error) => console.log(error)
+ * });
+ *
+ * const handlePost = (payload) => {
+ *   mutate(payload); // pass the payload to mutate function
+ * };
+ */
 
 export function useApiHelper<
   responseType = unknown,
@@ -10,21 +63,24 @@ export function useApiHelper<
 >({
   url,
   params,
-  queryKey = [],
+  queryKey,
   axiosOptions,
   method,
   onSuccess,
   onError,
   ...rest
-}: useApiHelperProps<responseType, errorType, payloadType>): ApiHelperResult<
-  responseType,
-  errorType,
-  payloadType
-> {
+}: useApiHelperProps<responseType, errorType, payloadType>):
+  | UseQueryResult<responseType, errorType>
+  | UseMutationResult<responseType, errorType, payloadType> {
   const { axiosInstance } = useApiHelperContext();
 
+  const defaultQueryKey: QueryKey = queryKey || [
+    url,
+    ...(params ? Object.values(params) : []),
+  ];
+
   const queryResult = useQuery<responseType, errorType>({
-    queryKey: queryKey || [],
+    queryKey: defaultQueryKey,
     queryFn: async () =>
       await apiRequest<responseType, errorType>(axiosInstance, 'GET', url, {
         params,

--- a/lib/types/GenericTypes.ts
+++ b/lib/types/GenericTypes.ts
@@ -1,7 +1,1 @@
-import { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-
-export type ApiHelperResult<responseType, errorType, payloadType> =
-  | UseQueryResult<responseType, errorType>
-  | UseMutationResult<responseType, errorType, payloadType>;

--- a/lib/types/useApiHelper.types.ts
+++ b/lib/types/useApiHelper.types.ts
@@ -13,7 +13,7 @@ export interface useApiHelperProps<
   url: string;
   params?: Record<string, unknown>;
   data?: payloadType;
-  queryKey: QueryKey;
+  queryKey?: QueryKey;
   axiosOptions?: AxiosRequestConfig;
   method: HTTPMethod;
   onSuccess?: (data: responseType) => void;

--- a/stories/PostDataStory.stories.tsx
+++ b/stories/PostDataStory.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Hooks/useApiHelper',
   args: {
     url: '/todos',
-    queryKey: 'post-todo',
+
     payload: { title: 'New Todo', completed: false },
   },
   argTypes: {
@@ -26,7 +26,7 @@ export default {
 } as Meta;
 
 export const PostDataStory: StoryFn = (args) => {
-  const { url, queryKey, payload } = args;
+  const { url, payload } = args;
 
   const onSuccess = (data: unknown) => {
     alert('Data posted successfully: ' + JSON.stringify(data));
@@ -36,31 +36,24 @@ export const PostDataStory: StoryFn = (args) => {
     alert('Error posting data:' + JSON.stringify(error));
   };
 
-  const apiHelperResult = useApiHelper({
+  const { mutate, isPending, isError } = useApiHelper({
     url: url,
-    queryKey: [queryKey],
     method: 'POST',
     onSuccess,
     onError,
   });
 
-  if ('mutate' in apiHelperResult) {
-    const { mutate, isPending, isError } = apiHelperResult;
+  const handlePost = () => {
+    console.log('Payload:', payload);
+    mutate(payload);
+  };
 
-    const handlePost = () => {
-      console.log('Payload:', payload);
-      mutate(payload);
-    };
-
-    return (
-      <div>
-        <h1>Post Data</h1>
-        <button onClick={handlePost}>Post Data</button>
-        {isPending && <div>Posting...</div>}
-        {isError && <div>Error posting data</div>}
-      </div>
-    );
-  }
-
-  return <div>Error: Expected a POST method but received something else.</div>;
+  return (
+    <div>
+      <h1>Post Data</h1>
+      <button onClick={handlePost}>Post Data</button>
+      {isPending && <div>Posting...</div>}
+      {isError && <div>Error posting data</div>}
+    </div>
+  );
 };

--- a/stories/PostDataStory.stories.tsx
+++ b/stories/PostDataStory.stories.tsx
@@ -44,7 +44,6 @@ export const PostDataStory: StoryFn = (args) => {
   });
 
   const handlePost = () => {
-    console.log('Payload:', payload);
     mutate(payload);
   };
 


### PR DESCRIPTION
Add documentation for the `ApiHelperProvider` and enhance the `useApiHelper` hook to support GET and mutation requests. Simplify related components and clean up unused code. Make `queryKey` optional in the hook's props.

Fixes #1